### PR TITLE
A subtotal for each product is now displayed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,6 @@ gem 'rails-controller-testing'
 # The gem below where added in order to silence a rails warning
 gem 'ostruct'
 
-# # The gems below where added in order to install bootstrap properly
-# gem 'bootstrap', '~> 5.3.0'
-# gem 'sassc-rails'
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.5"
 

--- a/app/views/carts/show.html.erb
+++ b/app/views/carts/show.html.erb
@@ -25,7 +25,7 @@
               <th>Product</th>
               <th>Price</th>
               <th>Quantity</th>
-              <th>Subtotal</th>
+              <th>Product subtotal</th>
               <th>Discount</th>
               <th>Actions</th>
             </tr>
@@ -60,7 +60,15 @@
           </tbody>
           <tfoot class="table-group-divider fw-bold">
             <tr>
-              <th colspan="3">Total price</th>
+              <th colspan="3">Subtotal</th>
+              <th class="text-success">
+                <% subtotal = @cart.cart_items.sum { |item| item.product.price * item.quantity } %>
+                <%= number_to_currency(subtotal) %>
+              </th>
+              <th colspan="2"></th>
+            </tr>
+            <tr>
+              <th colspan="3">Total price (with discounts)</th>
               <th class="text-success"><%= number_to_currency(@cart.total_price) %></th>
               <th colspan="2"></th>
             </tr>


### PR DESCRIPTION
A product subtotal is now applied, allowing the user to see the difference between normal price and the ones with the discounts applied.

![cart_with_some_products](https://github.com/user-attachments/assets/3821c117-2b9b-452d-94ef-84ef31a4b010)

And the discounts, of course, are applied automatically like before:

![cart_all_discounts_applied](https://github.com/user-attachments/assets/17c14203-3753-43c4-a1fa-c86a281870ce)
