### PR TITLE
refactor(view): move cart calculations and conditions to helpers/model

### DIFF
--- a/app/helpers/carts_helper.rb
+++ b/app/helpers/carts_helper.rb
@@ -1,2 +1,21 @@
 module CartsHelper
+  def bulk_threshold
+    DiscountRule::MIN_BULK_QTY
+  end
+
+  def pre_discount_subtotal(cart)
+    cart.cart_items.sum { |it| it.product.price * it.quantity }
+  end
+
+  def promo_applied_for(item)
+    rule = DiscountRule.find_by(product_code: item.product.code)
+    return nil unless rule
+
+    case rule.rule_type
+    when DiscountRule::T_BOGOF
+      "Promo applied" if item.quantity >= 2
+    when DiscountRule::T_BULK_PRICE, DiscountRule::T_BULK_PERCENT
+      "Promo applied" if item.quantity >= DiscountRule::MIN_BULK_QTY
+    end
+  end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,2 +1,15 @@
 module ProductsHelper
+  def promo_badge_for(product)
+    rule = DiscountRule.find_by(product_code: product.code)
+    return unless rule
+
+    case rule.rule_type
+    when DiscountRule::T_BOGOF
+      content_tag(:span, "Buy 1 Get 1", class: "badge bg-success")
+    when DiscountRule::T_BULK_PRICE
+      content_tag(:span, "Bulk price from #{DiscountRule::MIN_BULK_QTY}", class: "badge bg-info")
+    when DiscountRule::T_BULK_PERCENT
+      content_tag(:span, "Bulk discount from #{DiscountRule::MIN_BULK_QTY}", class: "badge bg-info")
+    end
+  end
 end

--- a/app/models/cart.rb
+++ b/app/models/cart.rb
@@ -41,6 +41,11 @@ class Cart < ApplicationRecord
     self
   end
 
+  def subtotal_for(item)
+    rule = DiscountRule.find_by(product_code: item.product.code)
+    price_for_group(item.product.price, item.quantity, rule)
+  end
+
   private
 
   def price_for_group(unit_price, qty, rule)

--- a/app/views/carts/_cart.html.erb
+++ b/app/views/carts/_cart.html.erb
@@ -35,15 +35,8 @@
                 <td><%= item.quantity %></td>
                 <td class="text-success"><%= number_to_currency(item.product.price * item.quantity) %></td>
                 <td>
-                  <% if rule %>
-                    <% case rule.rule_type %>
-                    <% when DiscountRule::T_BOGOF %>
-                      <span class="badge bg-custom-amber text-custom-dark">Buy one, get one free</span>
-                    <% when DiscountRule::T_BULK_PRICE %>
-                      <%= item.quantity >= DiscountRule::MIN_BULK_QTY ? "<span class='badge bg-custom-amber text-custom-dark'>#{number_to_currency(rule.value)} each (3+)</span>".html_safe : "<span class='badge bg-secondary'>None</span>".html_safe %>
-                    <% when DiscountRule::T_BULK_PERCENT %>
-                      <%= item.quantity >= DiscountRule::MIN_BULK_QTY ? "<span class='badge bg-custom-amber text-custom-dark'>2/3 price (3+)</span>".html_safe : "<span class='badge bg-secondary'>None</span>".html_safe %>
-                    <% end %>
+                  <% if promo_applied_for(item) %>
+                    <span class="badge bg-custom-amber text-custom-dark"><%= promo_applied_for(item) %></span>
                   <% else %>
                     <span class="badge bg-secondary">None</span>
                   <% end %>
@@ -58,8 +51,7 @@
             <tr>
               <th colspan="3">Subtotal</th>
               <th class="text-success">
-                <% subtotal = @cart.cart_items.sum { |item| item.product.price * item.quantity } %>
-                <%= number_to_currency(subtotal) %>
+                <%= number_to_currency(pre_discount_subtotal(cart)) %>
               </th>
               <th colspan="2"></th>
             </tr>


### PR DESCRIPTION
Cleans up the cart view by moving logic out of ERB and into the domain/helpers.

Changes
- Cart: adds `subtotal_for(item)` reusing the existing pricing logic per rule.
- CartHelper: adds `bulk_threshold`, `pre_discount_subtotal(cart)`, and `promo_applied_for(item)`.
- View: `app/views/carts/_cart.html.erb` uses helpers/model methods instead of inline math/conditions.

Why
- Views focus on presentation; pricing rules live in Ruby.
- Easier to read/maintain and simpler to test.

Scope/Impact
- No behavior/schema/route changes.

How to test
- `bin/rspec`
- Manual: add/remove items; line subtotal, subtotal (pre-discount) and total remain correct; discount label shows “Promo applied” when applicable.