### PR TITLE
feat(ux): consistent promo visibility (badges on products, applied-state in cart)

### DIFF
--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -10,13 +10,17 @@
     <ul class="list-group list-group-flush">
       <% @products.each do |product| %>
         <li class="list-group-item d-flex justify-content-between align-items-center">
+
           <div class="d-flex align-items-center">
             <span class="fw-bold me-2"><%= product.name %></span>
-            <span class="text-success"><%= number_to_currency(product.price) %></span>
+            <span class="text-success me-2"><%= number_to_currency(product.price) %></span>
+            <%= promo_badge_for(product) %>
           </div>
+
           <%= form_with(url: add_product_cart_path(product_id: product.id), method: :post) do |form| %>
             <%= form.submit "Add product to cart", class: "btn btn-sm border-0 bg-custom-amber text-custom-dark" %>
           <% end %>
+          
         </li>
       <% end %>
     </ul>

--- a/spec/views/products/index.html.erb_spec.rb
+++ b/spec/views/products/index.html.erb_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe "products/index", type: :view do
+  it "shows promo badges" do
+    p = Product.create!(code: Product::CODE_GR1, name: "Green Tea", price: 3.11)
+    DiscountRule.create!(name: "BOGOF", product_code: p.code, rule_type: DiscountRule::T_BOGOF)
+    assign(:products, [p])
+    assign(:cart, Cart.create!)
+
+    render
+    expect(rendered).to include("Buy 1 Get 1")
+  end
+end


### PR DESCRIPTION
Makes promotions consistent across the app.

Changes
- Products list: shows a badge for each product’s promotion (`Buy 1 Get 1`, `Bulk price from N`, `Bulk discount from N`).
- Cart: keeps the applied-state only (“Promo applied” when threshold is met), matching the new add-in-place flow.

Why
- Users always see which promo exists on the product card.
- The cart focuses on whether a promo is currently applied.

Scope/Impact
- No behavior changes to pricing; UI-only enhancement.
- Uses existing constants for thresholds/rule types.

How to test
- `bin/rspec`
- Manual: open `/products` and verify badges; add items until the rule applies, and see “Promo applied” in cart.