### PR TITLE
feat(react): replace products list with React component (keeps Turbo cart update)

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -3,6 +3,24 @@ class ProductsController < ApplicationController
 
   def index
     @products = Product.all
+    @cart = current_cart
+
+    respond_to do |format|
+      format.html
+      format.json do
+        render json: @products.map { |p|
+          rule = DiscountRule.find_by(product_code: p.code)
+          {
+            id: p.id,
+            code: p.code,
+            name: p.name,
+            price: p.price,
+            promo: rule&.rule_type,
+            promo_value: rule&.value
+          }
+        }
+      end
+    end
   end
 
   private

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,11 +1,18 @@
 import "@hotwired/turbo-rails";
 import { createRoot } from "react-dom/client";
 import HelloReact from "./components/HelloReact.jsx";
+import ProductsList from "./components/ProductsList.jsx";
 
 document.addEventListener("turbo:load", () => {
   const el = document.getElementById("react-root");
   if (el && !el.dataset.mounted) {
     createRoot(el).render(<HelloReact name="Ca-Ching-App" />);
-    el.dataset.mounted = "1";
+    hello.dataset.mounted = "1";
+  }
+
+  const pl = document.getElementById("products-react");
+  if (pl && !pl.dataset.mounted) {
+    createRoot(pl).render(<ProductsList />);
+    pl.dataset.mounted = "1";
   }
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -4,9 +4,9 @@ import HelloReact from "./components/HelloReact.jsx";
 import ProductsList from "./components/ProductsList.jsx";
 
 document.addEventListener("turbo:load", () => {
-  const el = document.getElementById("react-root");
-  if (el && !el.dataset.mounted) {
-    createRoot(el).render(<HelloReact name="Ca-Ching-App" />);
+  const hello = document.getElementById("react-root");
+  if (hello && !hello.dataset.mounted) {
+    createRoot(hello).render(<HelloReact name="Ca-Ching-App" />);
     hello.dataset.mounted = "1";
   }
 

--- a/app/javascript/components/ProductsList.jsx
+++ b/app/javascript/components/ProductsList.jsx
@@ -27,8 +27,6 @@ export default function ProductsList() {
                 {p.promo === "bulk_price" && <span className="badge bg-info">Bulk price from 3</span>}
                 {p.promo === "bulk_percentage" && <span className="badge bg-info">Bulk discount from 3</span>}
               </div>
-
-              {/* Form clásico ⇒ POST a /cart/add_product ⇒ Turbo actualiza el frame del carrito */}
               <form action="/cart/add_product" method="post" data-turbo="true">
                 <input type="hidden" name="authenticity_token" value={token} />
                 <input type="hidden" name="product_id" value={p.id} />

--- a/app/javascript/components/ProductsLists.jsx
+++ b/app/javascript/components/ProductsLists.jsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+
+export default function ProductsList() {
+  const [products, setProducts] = useState([]);
+  const token = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+
+  useEffect(() => {
+    fetch("/products.json", { headers: { Accept: "application/json" } })
+      .then(r => r.json())
+      .then(setProducts)
+      .catch(() => setProducts([]));
+  }, []);
+
+  return (
+    <div className="card mb-4 products-card">
+      <div className="card-header bg-custom-amber text-custom-dark">
+        <h2 className="h5 mb-0">Products (React)</h2>
+      </div>
+      <div className="card-body p-0">
+        <ul className="list-group list-group-flush">
+          {products.map(p => (
+            <li key={p.id} className="list-group-item d-flex justify-content-between align-items-center">
+              <div className="d-flex align-items-center">
+                <span className="fw-bold me-2">{p.name}</span>
+                <span className="text-success me-2">€{Number(p.price).toFixed(2)}</span>
+                {p.promo === "bogof" && <span className="badge bg-success">Buy 1 Get 1</span>}
+                {p.promo === "bulk_price" && <span className="badge bg-info">Bulk price from 3</span>}
+                {p.promo === "bulk_percentage" && <span className="badge bg-info">Bulk discount from 3</span>}
+              </div>
+
+              {/* Form clásico ⇒ POST a /cart/add_product ⇒ Turbo actualiza el frame del carrito */}
+              <form action="/cart/add_product" method="post" data-turbo="true">
+                <input type="hidden" name="authenticity_token" value={token} />
+                <input type="hidden" name="product_id" value={p.id} />
+                <button type="submit" className="btn btn-sm border-0 bg-custom-amber text-custom-dark">
+                  Add product to cart
+                </button>
+              </form>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -4,30 +4,7 @@
 
 <div id="react-root"></div>
 
-<div class="card mb-4 products-card">
-  <div class="card-header bg-custom-amber text-custom-dark">
-    <h2 class="h5 mb-0">Products</h2>
-  </div>
-  <div class="card-body p-0">
-    <ul class="list-group list-group-flush">
-      <% @products.each do |product| %>
-        <li class="list-group-item d-flex justify-content-between align-items-center">
-
-          <div class="d-flex align-items-center">
-            <span class="fw-bold me-2"><%= product.name %></span>
-            <span class="text-success me-2"><%= number_to_currency(product.price) %></span>
-            <%= promo_badge_for(product) %>
-          </div>
-
-          <%= form_with(url: add_product_cart_path(product_id: product.id), method: :post) do |form| %>
-            <%= form.submit "Add product to cart", class: "btn btn-sm border-0 bg-custom-amber text-custom-dark" %>
-          <% end %>
-
-        </li>
-      <% end %>
-    </ul>
-  </div>
-</div>
+<div id="products-react"></div>
 
 <div class="text-center mb-4">
   <turbo-frame id="cart">


### PR DESCRIPTION
Migrates the products list UI to React while preserving the existing cart flow.

Changes
- Controller: ProductsController#index now serves JSON (id, code, name, price, promo, promo_value).
- Frontend: new React component app/javascript/components/ProductsList.jsx
  - fetches /products.json on mount
  - renders list with promo badges
  - posts to /cart/add_product via a plain HTML form including authenticity_token
- Entry: app/javascript/application.js mounts <ProductsList /> on #products-react.
- View: app/views/products/index.html.erb replaces the ERB list with <div id="products-react"></div>.
- Cart flow unchanged: Turbo handles the cart frame refresh after add_product.

Why
- First real slice of UI in React (fetch → render) without reimplementing cart logic.
- Incremental migration: Rails stays as backend and source of pricing/discounts.

How to test
1) Run `npm run dev` and `bin/rails s`.
2) Open `/products`: see “Products (React)” with items and promo badges.
3) Click “Add product to cart”: the cart section updates in place (no full page reload).
4) `/products.json` returns the product array as expected.